### PR TITLE
Support for the DOS II+ (and XDOS) file management system dir flag idiosyncrasy

### DIFF
--- a/libatr/dos2_filesystem.cpp
+++ b/libatr/dos2_filesystem.cpp
@@ -66,7 +66,7 @@ const filesystem::property * dos2::properties()
 	return props;
 }
 
-dos2::dos2(disk * d, bool use_file_number) : filesystem(d), use_file_number(use_file_number)
+dos2::dos2(disk * d, bool use_file_number,bool force_dos2_flag) : filesystem(d), use_file_number(use_file_number),force_dos2_flag(force_dos2_flag)
 {
 }
 
@@ -270,7 +270,7 @@ void dos2::dos2_file::write_data_sector(disk::sector_num next)
 	sec->poke(--p, sec_hi);
 	
 	sector = next;
-	if (sector > 720) {
+	if (sector > 720 && !fs.force_dos2_flag) {
 		dos2_compatible = false;
 	}
 	sec_cnt++;

--- a/libatr/dos2_filesystem.h
+++ b/libatr/dos2_filesystem.h
@@ -37,7 +37,7 @@ public:
 	static disk::sector_num DIR_FIRST_SECTOR;
 	static size_t           DIR_SIZE;
 
-	dos2(disk * d, bool use_file_number = true);
+	dos2(disk * d, bool use_file_number = true, bool force_dos2_flag=false);
 	~dos2();
 
 	static filesystem * format(disk * d);
@@ -91,6 +91,7 @@ public:
 		size_t sec_cnt;					// size if not known yet
 		size_t size;					// size in bytes
 		bool dos2_compatible;
+                
 	};
 
 	class dos2_dir : public filesystem::dir
@@ -135,4 +136,5 @@ protected:
 
 	bool use_file_number;
 	byte fs_file_flags;
+    bool force_dos2_flag;
 };

--- a/libatr/dos_IIplus.cpp
+++ b/libatr/dos_IIplus.cpp
@@ -50,6 +50,6 @@ const filesystem::property * dos_IIplus::properties()
 	return props;
 }
 
-dos_IIplus::dos_IIplus(disk * d) : expanded_vtoc(d)
+dos_IIplus::dos_IIplus(disk * d) : expanded_vtoc(d,true,true)
 {
 }

--- a/libatr/expanded_vtoc.h
+++ b/libatr/expanded_vtoc.h
@@ -38,7 +38,7 @@ For medium density version in VTOC is 3, number of sectors is $403 (=1027).
 class expanded_vtoc : public dos2 
 {
 protected:
-	expanded_vtoc(disk * d, bool use_file_numbers = true) : dos2(d, use_file_numbers) {}
+	expanded_vtoc(disk * d, bool use_file_numbers = true,bool force_dos2_flag = false) : dos2(d, use_file_numbers,force_dos2_flag) {}
 
 	void switch_sector_use(disk::sector_num sec, byte count = 1) override;
 	disk::sector_num alloc_sector() override;


### PR DESCRIPTION
When a disk is formatted to medium density (130 KB), DOS II+ sets the $42 directory flags
for all files, and not only files located belov sector 720. This has been observed by formatting a blank disk to medium density with DOS II+ and adding files until the disk was full.

This commit adds one parameter to the constructors of the dos2 and expanded_vtoc classes.
The parameter is force_dos2_flag with default value of false.
When the parameter is true, files located above sector 720 do not have their DOS 2 flag reset.

The dos_IIplus constructor (and therefore XDOS) calls the super class constructor with force_dos2_flag=true, so files of the XDOS and DOS II+ filesystems always have $42 in their directory entries. Other file systems DOS2 DOS 2.5 etc. are not affected.